### PR TITLE
Small fixes on fake application triggers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,8 +161,7 @@
             android:name=".trigger.application.ApplicationActivity"
             android:taskAffinity=".trigger.application"
             android:noHistory="true"
-            android:theme="@android:style/Theme.NoDisplay"
-            android:enabled="false"
+            android:theme="@style/Base.Theme.AppCompat"
             android:exported="false">
         </activity>
 
@@ -181,7 +180,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity-alias>
-        
+
         <activity-alias
             android:name=".trigger.application.TelegramActivity"
             android:targetActivity=".trigger.application.ApplicationActivity"


### PR DESCRIPTION
Fix for 
```View class androidx.appcompat.widget.AppCompatTextView is an AppCompat widget that can only be used with a Theme.AppCompat theme (or descendant).```

- Main ApplicationActivity needs to use AppCompat theme.

Fix for 
```android.content.pm.PackageManager$NameNotFoundException: ComponentInfo{me.lucky.wasted/me.lucky.wasted.trigger.application.ApplicationActivity}```

- Main ApplicationActivity was not enabled.